### PR TITLE
Updated path argument in identify.py

### DIFF
--- a/extract/extract.py
+++ b/extract/extract.py
@@ -885,7 +885,7 @@ class Extract(ServiceBase):
                 f.close()
 
                 to_add = True
-                file_info = ident(byte_block, len(byte_block))
+                file_info = ident(byte_block, len(byte_block), cur_file[0])
                 for exp in whitelisted_tags_re:
                     if exp.search(file_info['type']):
                         if DEBUG:


### PR DESCRIPTION
identify.py's ident() method has a `path` argument as of https://github.com/CybercentreCanada/assemblyline-base/commit/8dd9b3a485340c1529fe77d10b3aad47e010039e#diff-494a12c9050e25c2afae18ce770ad2c3 and occasionally Extract errors on this because the service code has not been updated to reflect this change in ident().

See prod for examples of hashes that cause this error: 
```
Extract [EXCEPTION] :: 4.0.0.stable1

  File "/var/lib/assemblyline/.local/lib/python3.7/site-packages/assemblyline_v4_service/common/base.py", line 79, in handle_task
    self.execute(request)
  File "/opt/al_service/extract/extract.py", line 114, in execute
    password_protected, white_listed = self.extract(request, local)
  File "/opt/al_service/extract/extract.py", line 223, in extract
    extracted, white_listed_count = white_listing_method(extracted, white_listed_count, encoding)
  File "/opt/al_service/extract/extract.py", line 888, in jar_whitelisting
    file_info = ident(byte_block, len(byte_block))
TypeError: ident() missing 1 required positional argument: 'path'
```