### PR TITLE
adding functionality to handle password protected office files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,18 +17,15 @@ USER assemblyline
 
 # Install pip packages
 RUN touch /tmp/before-pip
-RUN pip install --no-cache-dir --user tnefparse olefile beautifulsoup4 pylzma lxml && rm -rf ~/.cache/pip
+RUN pip install --no-cache-dir --user tnefparse olefile beautifulsoup4 pylzma lxml msoffcrypto-tool && rm -rf ~/.cache/pip
 
 # Download the support files from Amazon S3
-RUN wget -O /tmp/msoffice.tar.gz https://assemblyline-support.s3.amazonaws.com/msoffice.tar.gz
 RUN wget -O /tmp/cybozulib.tar.gz https://assemblyline-support.s3.amazonaws.com/cybozulib.tar.gz
 
 # Extract the tar files and make msoffice
 USER root
 RUN mkdir -p /opt/al/support/extract
-RUN tar -zxf /tmp/msoffice.tar.gz -C /opt/al/support/extract
 RUN tar -zxf /tmp/cybozulib.tar.gz -C /opt/al/support/extract
-RUN make -C /opt/al/support/extract/msoffice -j RELEASE=1
 
 # Remove files that existed before the pip install so that our copy command below doesn't take a snapshot of
 # files that already exist in the base image

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -2,7 +2,7 @@ name: Extract
 version: $SERVICE_TAG
 description: This service extracts embedded files from file containers (like ZIP, RAR, 7z, ...).
 
-accepts: (archive|executable|java)/.*|code/vbe|code/html|document/email|document/pdf|document/office/unknown|android/apk|ios/ipa
+accepts: (archive|executable|java)/.*|code/vbe|code/html|document/email|document/pdf|document/office/passwordprotected|android/apk|ios/ipa
 rejects: empty|metadata/.*
 
 stage: EXTRACT
@@ -17,6 +17,7 @@ is_external: false
 licence_count: 0
 
 config:
+  # Must be all strings
   default_pw_list: [password, infected, VelvetSweatshop, add_more_passwords]
   named_email_attachments_only: true
   max_email_attachment_size: 10737418240
@@ -69,7 +70,7 @@ heuristics:
   - heur_id: 6
     name: Office password removed
     score: 0
-    filetype: document/office/unknown
+    filetype: document/office/passwordprotected
     description: Password removed from password-protected office document
 
   - heur_id: 7

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -71,7 +71,7 @@ heuristics:
     name: Office password removed
     score: 0
     filetype: document/office/passwordprotected
-    description: Password removed from password-protected office document
+    description: Extracted from protected office document
 
   - heur_id: 7
     name: Extracted from PDF


### PR DESCRIPTION
Made some changes to have extract receive password protected office files (tested with doc, docx, docm, xls, xlsx, xlsm, ppt, pptx file types) and to decrypt those files prior to being sent to other services. This avoids the issue of services like Cuckoo not being able to handle password protected files at this time. 

https://github.com/CybercentreCanada/assemblyline-base/pull/46