### PR TITLE
Zipped cart handling

### DIFF
--- a/extract/extract.py
+++ b/extract/extract.py
@@ -326,7 +326,7 @@ class Extract(ServiceBase):
             encoding: AL tag with string 'archive/' replaced.
 
         Returns:
-            List containing decoded file path, encoding, and display name "[orig FH name]_decoded", or a blank list if
+            List containing decoded file path, encoding, and display name "[orig FH name]", or a blank list if
             decryption failed; and True if encryption successful (indicating encryption detected).
         """
         # When encrypted, AL will identify the document as a passwordprotected office type.

--- a/extract/extract.py
+++ b/extract/extract.py
@@ -334,7 +334,7 @@ class Extract(ServiceBase):
 
         out_name, password = res
         self._last_password = password
-        display_name = "_decoded".join(os.path.splitext(os.path.basename(request.file_path)))
+        display_name = request.file_name
         return [[out_name, display_name, encoding]], True
 
     def _7zip_submit_extracted(self, request: ServiceRequest, path: str, encoding: str):

--- a/extract/extract.py
+++ b/extract/extract.py
@@ -113,7 +113,7 @@ class Extract(ServiceBase):
 
         #Check if the file itself is archive/cart
         if cart_ident(request.file_path) != 'corrupted/cart':
-            self.log.info("File is cARTed. Will be un-cARTed and appended to result")
+            self.log.info("File is cARTed. Will be un-cARTed and processed")
             uncart_output = tempfile.NamedTemporaryFile()
 
             with open(request.file_path, 'rb') as ifile, open(uncart_output.name, 'wb') as ofile:
@@ -333,7 +333,6 @@ class Extract(ServiceBase):
         if request.file_type != "document/office/passwordprotected":
             return [], False
 
-        self.log.info(request.task.__dict__)
         passwords = self.get_passwords(request)
         try:
             res = extract_office_docs(local, passwords, self.working_directory)

--- a/extract/extract.py
+++ b/extract/extract.py
@@ -6,15 +6,16 @@ import shutil
 import subprocess
 import tempfile
 import zlib
-from copy import deepcopy
 
 from bs4 import BeautifulSoup
+from cart import get_metadata_only, unpack_stream
+from copy import deepcopy
 from extract.ext.office_extract import extract_office_docs, ExtractionError, PasswordError
 from extract.ext.repair_zip import RepairZip, BadZipfile
 from extract.ext.xxxswf import xxxswf
 from lxml import html, etree
 
-from assemblyline.common.identify import ident
+from assemblyline.common.identify import fileinfo, ident, cart_ident
 from assemblyline.common.str_utils import safe_str
 from assemblyline_v4_service.common.base import ServiceBase
 from assemblyline_v4_service.common.request import ServiceRequest, MaxExtractedExceeded
@@ -109,6 +110,19 @@ class Extract(ServiceBase):
         local = request.file_path
         password_protected = False
         white_listed = 0
+
+        #Check if the file itself is archive/cart
+        if cart_ident(request.file_path) != 'corrupted/cart':
+            self.log.info("File is cARTed. Will be un-cARTed and appended to result")
+            uncart_output = tempfile.NamedTemporaryFile()
+
+            with open(request.file_path, 'rb') as ifile, open(uncart_output.name, 'wb') as ofile:
+                unpack_stream(ifile, ofile)
+
+            #Proceed extract process as uncarted file
+            request.file_name = get_metadata_only(request.file_path)['name']
+            request.file_type = fileinfo(uncart_output.name)['type']
+            local = uncart_output.name
 
         try:
             password_protected, white_listed = self.extract(request, local)
@@ -319,6 +333,7 @@ class Extract(ServiceBase):
         if request.file_type != "document/office/passwordprotected":
             return [], False
 
+        self.log.info(request.task.__dict__)
         passwords = self.get_passwords(request)
         try:
             res = extract_office_docs(local, passwords, self.working_directory)


### PR DESCRIPTION
Ran into odd issue where if we submit an archive of carts, Extract gets the carted files but doesn't know how to handle them.

Extract will check if the file being processed is carted or not, if so it will proceed with the uncarted version of the file.

Example:
![image](https://user-images.githubusercontent.com/62077998/108763440-6098e180-751f-11eb-92ff-22c925af9684.png)
