### PR TITLE
Fix pop extracted when add_extracted failed

### DIFF
--- a/extract/extract.py
+++ b/extract/extract.py
@@ -240,13 +240,14 @@ class Extract(ServiceBase):
             for white_listing_method in self.white_listing_methods:
                 extracted, white_listed_count = white_listing_method(extracted, white_listed_count, encoding)
 
-        for i, child in enumerate(extracted):
+        extracted_count = len(extracted)
+        for child in extracted:
             try:
-                # If the file is not successfully added as extracted, then pop it from the list of extracted
+                # If the file is not successfully added as extracted, then decrease the extracted file counter
                 if not request.add_extracted(*child):
-                    extracted.pop(i)
+                    extracted_count -= 1
             except MaxExtractedExceeded:
-                raise MaxExtractedExceeded(f"This file contains {len(extracted)} extracted files, exceeding the "
+                raise MaxExtractedExceeded(f"This file contains {extracted_count} extracted files, exceeding the "
                                            f"maximum of {request.max_extracted} extracted files allowed. "
                                            "None of the files were extracted.")
 


### PR DESCRIPTION
A small patch to fix pop on iterated list, leading to a potential vulnerability.

If you push an archive containing a mix of empty files and regular files, each time an empty file is encountered a regular file will be skipped in the iteration. This could easily be used to hide malware in an archive.

In python, you should not modify a list while you are iterating on it:
```python3
letters = ["a", "b", "c", "d"]
for i, x in enumerate(letters):
     print(f"{i}: {x}")
     _ = letters.pop(i)
```
Expected:
```python3
0: a
1: b
2: c
3: d
```
Actual behaviour:
```python3
0: a
1: c
```