### PR TITLE
Remove email parsing from extract

### DIFF
--- a/extract/extract.py
+++ b/extract/extract.py
@@ -94,14 +94,8 @@ class Extract(ServiceBase):
         ]
         self.anomaly_detections = [self.archive_with_executables, self.archive_is_arc]
         self.white_listing_methods = [self.jar_whitelisting, self.ipa_whitelisting]
-        self.named_attachments_only = None
-        self.max_attachment_size = None
         self.is_ipa = False
         self.sha = None
-
-    def start(self):
-        self.named_attachments_only = self.config.get('NAMED_EMAIL_ATTACHMENTS_ONLY', True)
-        self.max_attachment_size = self.config.get('MAX_EMAIL_ATTACHMENT_SIZE', None)
 
     def execute(self, request: ServiceRequest):
         """Main Module. See README for details."""

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -61,12 +61,6 @@ heuristics:
     filetype: android/
     description: Files were extracted from an APK file
 
-  - heur_id: 5
-    name: Attachements extracted
-    score: 0
-    filetype: document/eml
-    description: Attachments were extracted from EML file
-
   - heur_id: 6
     name: Office password removed
     score: 0

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -19,8 +19,6 @@ licence_count: 0
 config:
   # Must be all strings
   default_pw_list: [password, infected, VelvetSweatshop, add_more_passwords]
-  named_email_attachments_only: true
-  max_email_attachment_size: 10737418240
 
 submission_params:
   - default: ''


### PR DESCRIPTION
Removing email parsing from extract in favor of having it in eml_parser,
which extracts attachments and also provides header info.