### PR TITLE
Add attribute to class

### DIFF
--- a/extract/ext/repair_zip.py
+++ b/extract/ext/repair_zip.py
@@ -143,6 +143,7 @@ class RepairZip(ZipFile):
         self._lock = threading.RLock()
         self._seekable = True
         self._writing = False
+        self._strict_timestamps = True
 
         # Check if we were passed a file-like object
         if isinstance(filename, str):


### PR DESCRIPTION
Diff between zipfile in Python [3.7](https://github.com/python/cpython/blob/d5650a1738fe34f6e1db4af5f4c4edb7cae90a36/Lib/zipfile.py#L1208) vs [3.9](https://github.com/python/cpython/blob/4ce55cceb2901c564962f724448a9ced00c8a738/Lib/zipfile.py#L1206) resulting the service crashing when attempting to repair a zip (common for onenote files)