### PR TITLE
Fixing a possible None in extract_script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ USER assemblyline
 
 # Install pip packages
 RUN touch /tmp/before-pip
-RUN pip install --no-cache-dir --user tnefparse olefile beautifulsoup4 pylzma lxml msoffcrypto-tool && rm -rf ~/.cache/pip
+RUN pip install --no-cache-dir --user tnefparse olefile beautifulsoup4 pylzma lxml msoffcrypto-tool html5lib && rm -rf ~/.cache/pip
 
 # Download the support files from Amazon S3
 RUN wget -O /tmp/cybozulib.tar.gz https://assemblyline-support.s3.amazonaws.com/cybozulib.tar.gz

--- a/extract/extract.py
+++ b/extract/extract.py
@@ -1109,7 +1109,7 @@ class Extract(ServiceBase):
         with open(local, 'rb') as f:
             data = f.read()
 
-        soup = BeautifulSoup(data, features='lxml')
+        soup = BeautifulSoup(data, features='html5lib')
         scripts = soup.findAll("script")
         extracted = []
         for script in scripts:

--- a/extract/extract.py
+++ b/extract/extract.py
@@ -1113,6 +1113,8 @@ class Extract(ServiceBase):
         scripts = soup.findAll("script")
         extracted = []
         for script in scripts:
+            if script.string is None:
+                continue
             encoded_script = str(script.string).encode()
             with tempfile.NamedTemporaryFile(dir=self.working_directory, delete=False) as out:
                 out.write(encoded_script)


### PR DESCRIPTION
script.string is None when the script tags are empty, which also
happens if the script is too large for BeautifulSoup to parse.