### PR TITLE
use safelist always; use deep_scan to ignore safelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It will also:
     - The body of an .eml file (separated once by whitespace characters and second on [a-zA-Z0-9]+)
 - Use pdfdetach in poppler-utils to extract attachments from pdf samples;
 
-Once this service has completed its processing, it will block samples from continuing to other services unless they are 
+Once this service has completed its processing, it will block samples from continuing to other services unless they are
 identified as the following file types:
 
     - Executables
@@ -31,14 +31,17 @@ identified as the following file types:
     - Document files (i.e. Microsoft Office and PDF)
     - Apple/IPA packages
 
+**NOTE**: This service will avoid adding unnecessary files if the files are known to the system to be safe. This can be
+overridden by running the service task with `deep_scan` enabled.
+
 ## Submission Parameters & Configuration
 
 ### Parameters:
 
 - `Password`: An additional password can be provided to the service on submission to decode a container.
 - `Extract PE Sections`: Using the 7zip library, the service will extract sections from an executable file.
-- `Continue After Extract`: When true, AL will continue processing an eml sample to other services after any attachments 
-have been extracted. 
+- `Continue After Extract`: When true, AL will continue processing an eml sample to other services after any attachments
+have been extracted.
 
 ### Config (set by administrator):
 

--- a/extract/extract.py
+++ b/extract/extract.py
@@ -275,14 +275,18 @@ class Extract(ServiceBase):
         symlinks = []
         for child in extracted:
             try:
-                is_safelisted = self.api_interface.lookup_safelist(child[0])
+                sha256 = hashlib.sha256()
+                sha256.update(open(child[0], 'rb').read())
+                sha256_hash = sha256.hexdigest()
+                is_safelisted = self.api_interface.lookup_safelist(sha256_hash)
                 if os.path.islink(child[0]):
                     link_desc = f"{child[1]} -> {os.readlink(child[0])}"
                     symlinks.append(link_desc)
                     self.log.info(f"Symlink detected: {link_desc}")
                     extracted_count -= 1
                 # Not including files that are system-safelisted (takes up extracted_files allocation of submission)
-                elif not request.deep_scan and is_safelisted and is_safelisted['enabled'] and is_safelisted['tag'] == 'file':
+                elif not request.deep_scan and is_safelisted and is_safelisted['enabled'] and is_safelisted['type'] == 'file':
+                    self.log.info("File hash found in safelist. Not including in extracted_files list of submission..")
                     extracted_count -= 1
                 # If the file is not successfully added as extracted, then decrease the extracted file counter
                 elif not request.add_extracted(*child):


### PR DESCRIPTION
Addresses: https://github.com/CybercentreCanada/assemblyline-service-extract/issues/39

The service will leverage the safelist to avoid adding extracted files that we know are safe, leaving more room for files that we don't know about.

If an analyst wants to know everything that was extracted, then they can run the sample with the `deep_scan` flag and increase the `max_extracted` files value in the submission parameters.