### PR TITLE
Handling RuntimeError in repair_zip()

### DIFF
--- a/extract/extract.py
+++ b/extract/extract.py
@@ -369,6 +369,11 @@ class Extract(ServiceBase):
         except NotImplementedError:
             # Compression type 99 is not implemented in python zipfile
             return [], False
+        except RuntimeError:
+            # Probably a corrupted passworded file.
+            # Since we have no examples of good usage of repair_zip, we'll just make sure it won't error out.
+            # We won't support repairing corrupted passworded files for now.
+            return [], False
 
     # noinspection PyCallingNonCallable
     def extract_office(self, request: ServiceRequest, local, encoding: str):

--- a/extract/extract.py
+++ b/extract/extract.py
@@ -373,6 +373,9 @@ class Extract(ServiceBase):
             # Probably a corrupted passworded file.
             # Since we have no examples of good usage of repair_zip, we'll just make sure it won't error out.
             # We won't support repairing corrupted passworded files for now.
+            self.log.warning(
+                "RuntimeError detected. Is the corrupted file password protected? That is usually the cause."
+            )
             return [], False
 
     # noinspection PyCallingNonCallable


### PR DESCRIPTION
Based on issue #46 
Will stop the service from throwing an exception altogether.

I would need some examples of what the code was supposed to do to try to fix it in a better way, without breaking the expected behaviour. Since there are no examples of how it's used, I'll leave keep the modifications simple.