### PR TITLE
Adding passwords from oletools default list

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -20,7 +20,8 @@ uses_temp_submission_data: true
 
 config:
   # Must be all strings
-  default_pw_list: [password, infected, VelvetSweatshop, add_more_passwords]
+  default_pw_list: [password, infected, VelvetSweatshop, '/01Hannes Ruescher/01',
+                    '123', '1234', '12345', '123456', '4321']
   small_size_bypass_drop: 10485760
   max_file_count_bypass_drop: 5
   heur16_max_file_count: 5


### PR DESCRIPTION
Passwords sourced from https://github.com/decalage2/oletools/blob/f2cbbbaea5e8a809360ab338bd54ae281e4fd54f/oletools/crypto.py#L299.
I am assuming 'add_more_passwords' was a placeholder, if it is an actual password we want to keep I can put it back.