### PR TITLE
Handle mobi files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ debloat==1.5.3.3
 zstandard
 autoit-ripper
 python-gnupg
+mobi

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -2,7 +2,7 @@ name: Extract
 version: $SERVICE_TAG
 description: This service extracts embedded files from file containers (like ZIP, RAR, 7z, ...).
 
-accepts: (archive|executable|java)/.*|code/vbe|code/html|code/hta|code/wsf|code/a3x|document/installer/windows|document/pdf.*|document/office/onenote|document/office/passwordprotected|document/epub|android/apk|ios/ipa|gpg/symmetric
+accepts: (archive|executable|java)/.*|code/vbe|code/html|code/hta|code/wsf|code/a3x|document/installer/windows|document/pdf.*|document/office/onenote|document/office/passwordprotected|document/epub|document/mobi|android/apk|ios/ipa|gpg/symmetric
 rejects: empty|metadata/.*
 
 stage: EXTRACT


### PR DESCRIPTION
Follow-up for issue CybercentreCanada/assemblyline/issues/203
Relies on https://github.com/iscc/mobi since Mobi files are not simple zip files, as opposed to epub.